### PR TITLE
Set mailcatcher config to not use ssl

### DIFF
--- a/config/soflomo_mail.global.php.dist
+++ b/config/soflomo_mail.global.php.dist
@@ -88,6 +88,9 @@ return array(
                 'host' => '127.0.0.1',
                 'port' => 1025,
                 'connection_class'  => 'smtp',
+                'connection_config' => array(
+                    'ssl' => null,
+                ),
             ),
         ),
         */


### PR DESCRIPTION
Mailcatcher does not support ssl, which is on by default, so i've updated the example config to not use SSL.
