### PR TITLE
Force multipart/alternative Content-Type header when both text/plain …

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -208,6 +208,10 @@ class MailService implements MailServiceInterface
         $body->addPart($htmlPart);
 
         $message->setBody($body);
+        
+        if($body->isMultiPart()) {
+            $message->getHeaders()->get('content-type')->setType('multipart/alternative');
+        }
     }
 
     /**


### PR DESCRIPTION
…and text/html parts are used

This update is necessary because the function MailService:addCustomHeaders adds a second Content-Type header instead of replace the default Content-Type header (multipart/mixed)